### PR TITLE
cambiando version de dependencia

### DIFF
--- a/ProyectoRest/pom.xml
+++ b/ProyectoRest/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.9.9</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
cambié la versión de la dependencia de json fast a 2.9.9 por una alerta de seguridad